### PR TITLE
Add rule of workspace for S4 to ReadMe.txt

### DIFF
--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -4,3 +4,12 @@ ReadMeを読んで各自リポジトリをうまく使うこと。ReadMeは随�
 各自のプログラムファイルは、Personalフォルダ以下に作成すること。
 Personalフォルダ以下に、自分の学籍番号と苗字を使ったフォルダを作ること。
 例　br180001_ichikawa （全部小文字、アンダースコアで連結）
+
+## S4のWorkspaceについて
+`Personal`フォルダ以下の各自のフォルダに`Workspace`をワークスペースに設定すること
+
+```
+Personal
+|- bp18000_shibaura
+    |- Workspace
+```


### PR DESCRIPTION
S4のワークスペースについてのルールをReadMe.txtに追加しました。

S4の新規ワークスペースは空のディレクトリを指定する必要があります。なので、手順の統一を図るために各自のディレクトリにWorkspaceディレクトリを作成して、そこをワークスペースに指定する方式をとろうと思います。

S4個別の説明を共有リポジトリのReadMeに追加するのも微妙におかしいのかな、とは思いましたが、みんなが一番に見るのはここかなと思い、ReadMeに追加しました。
他に置く必要があれば、その位置を指定してください。

よろしくお願いいたします。