### PR TITLE
.gitattributesの追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*       text=auto
+*.sim   binary


### PR DESCRIPTION
S4のモデルファイルがバイナリ形式なので、バイナリファイルを扱う時の設定を追加した。